### PR TITLE
Added retry_non_idempotent=true to HTTP post requests

### DIFF
--- a/src/eutils.jl
+++ b/src/eutils.jl
@@ -74,7 +74,7 @@ retmode, sort, field, datetype, reldate, mindate, maxdate.
 """
 function esearch(ctx::Associative=empty_context(); params...)
     params = process_parameters(params, ctx)
-    res = HTTP.request("GET", string(baseURL, "esearch.fcgi"), query=params)
+    res = HTTP.request("GET", string(baseURL, "esearch.fcgi"), query=params, retry_non_idempotent=true)
     if get(params, :usehistory, "") == "y"
         set_context!(ctx, res)
     end
@@ -120,7 +120,7 @@ strand, seq_start, seq_stop, complexity.
 function efetch(ctx::Associative=empty_context(); params...)
     params = process_parameters(params, ctx)
     body = HTTP.escapeuri(params)
-    return HTTP.request("POST", string(baseURL, "efetch.fcgi"), query=body)
+    return HTTP.request("POST", string(baseURL, "efetch.fcgi"), query=body, retry_non_idempotent=true)
 end
 
 """

--- a/src/umls.jl
+++ b/src/umls.jl
@@ -161,7 +161,7 @@ function get_ticket(tgt)
     "Accept"=> "text/plain", "User-Agent"=>"JuliaBioServices" )
     r = HTTP.Response(503)
     try
-        r = HTTP.request("POST", tgt; body=body, headers=headers)
+        r = HTTP.request("POST", tgt; body=body, headers=headers, retry_non_idempotent=true)
     catch
         isdefined(r, :code) ? error("UMLS GET error: ", r.code) : error("UMLS COULD NOT GET")
     end
@@ -227,7 +227,7 @@ function search_umls(tgt, query; version::String="current", timeout=1)
         query["ticket"]= ticket
         query["pageNumber"]= string(page)
 
-        r = HTTP.request("GET", rest_uri*content_endpoint, query=query, timeout=timeout)
+        r = HTTP.request("GET", rest_uri*content_endpoint, query=query, timeout=timeout, retry_non_idempotent=true)
 
         if r.status != 200
             error("Bad HTTP status $(r.status)")

--- a/src/umls.jl
+++ b/src/umls.jl
@@ -227,7 +227,7 @@ function search_umls(tgt, query; version::String="current", timeout=1)
         query["ticket"]= ticket
         query["pageNumber"]= string(page)
 
-        r = HTTP.request("GET", rest_uri*content_endpoint, query=query, timeout=timeout, retry_non_idempotent=true)
+        r = HTTP.request("GET", rest_uri*content_endpoint, query=query, timeout=timeout)
 
         if r.status != 200
             error("Bad HTTP status $(r.status)")


### PR DESCRIPTION
# Added retry_non_idempotent=true to HTTP post requests

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [X] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

- If you have implemented new features or behaviour
  - **Provide a description of the addition** in as many details as possible.
On efetch and esearch added named variable of retry_non_idempotent set to true (default is false).  As these are post requests HTTP is not retrying them if eutils is non-responsive, but as they are functionally get requests there is no harm in resending them

This was change was recommended as a fix to this issue [here](https://github.com/JuliaWeb/HTTP.jl/issues/220)

  - **Provide justification of the addition**.
This was causing issues in BioMedQuery where many eutils requests are made.  Specifically when efetching with a list of PMIDs.

  - **Provide a runnable example of use of your addition**. This lets reviewers
    and others try out the feature before it is merged or makes it's way to release.
There is no noticeable change to functionality, behavior, just less likely to get an IOError from HTTP.

- If you have changed current behaviour...
  - **Describe the behaviour prior to you changes**
There is no noticeable change to functionality, behavior, just less likely to get an IOError from HTTP.

  - **Describe the behaviour after your changes** and justify why you have made the changes,
    Please describe any breakages you anticipate as a result of these changes.
There is no noticeable change to functionality, behavior, just less likely to get an IOError from HTTP.

  - **Does your change alter APIs or existing exposed methods/types?**
    If so, this may cause dependency issues and breakages, so the maintainer
    will need to consider this when versioning the next release.
No.

  - If you are implementing changes that are intended to increase performance, you
    should provide the results of a simple performance benchmark exercise
    demonstrating the improvement. Especially if the changes make code less legible.

## :ballot_box_with_check: Checklist

- [X] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [X] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [X] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [X] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [X] :ok: All changes should be compatible with the latest stable version of Julia.
- [X] :thought_balloon: I have commented liberally for any complex pieces of internal code.
