### PR TITLE
Change functions to use XMLDict instead of EzXML

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-EzXML 0.5
+XMLDict
 JSON
 Gumbo 0.4.0
 HTTP

--- a/src/eutils.jl
+++ b/src/eutils.jl
@@ -42,7 +42,6 @@ export
     espell,
     ecitmatch
 
-using LightXML
 import XMLDict
 import JSON
 import HTTP

--- a/src/eutils.jl
+++ b/src/eutils.jl
@@ -42,7 +42,8 @@ export
     espell,
     ecitmatch
 
-import EzXML
+using LightXML
+import XMLDict
 import JSON
 import HTTP
 
@@ -189,9 +190,9 @@ function set_context!(ctx, res)
     data = String(res.body)
 
     if startswith(contenttype, "text/xml")
-        doc = EzXML.parsexml(data)
-        ctx[:WebEnv] = EzXML.nodecontent(findfirst(doc, "//WebEnv"))
-        ctx[:query_key] = EzXML.nodecontent(findfirst(doc, "//QueryKey"))
+        doc = XMLDict.parse_xml(data)
+        ctx[:WebEnv] = doc["WebEnv"]
+        ctx[:query_key] = doc["QueryKey"]
     elseif startswith(contenttype, "application/json")
         dict = JSON.parse(data)
         ctx[:WebEnv] = dict["esearchresult"]["webenv"]

--- a/test/eutils.jl
+++ b/test/eutils.jl
@@ -4,8 +4,9 @@
         res = einfo(db="pubmed")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
-        @test isa(parsexml(res.body), EzXML.Document)
-        @test nodename(elements(root(parsexml(res.body)))[1]) != "ERROR"
+        body = parse_xml(String(res.body))
+        @test isa(body, XMLDict.XMLDictElement)
+        @test first(body)[1] != "ERROR"
     end
 
     @testset "esearch" begin
@@ -14,8 +15,9 @@
                                         "3000"[Date - Publication])""")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
-        @test isa(parsexml(res.body), EzXML.Document)
-        @test nodename(elements(root(parsexml(res.body)))[1]) != "ERROR"
+        body = parse_xml(String(res.body))
+        @test isa(body, XMLDict.XMLDictElement)
+        @test first(body)[1] != "ERROR"
     end
 
     @testset "epost" begin
@@ -23,7 +25,8 @@
         res = epost(ctx, db="protein", id="NP_005537")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
-        @test isa(parsexml(res.body), EzXML.Document)
+        body = parse_xml(String(res.body))
+        @test isa(body, XMLDict.XMLDictElement)
         @test haskey(ctx, :WebEnv)
         @test haskey(ctx, :query_key)
     end
@@ -33,14 +36,16 @@
         res = esummary(db="protein", id="15718680,157427902,119703751")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
-        @test isa(parsexml(res.body), EzXML.Document)
-        @test nodename(elements(root(parsexml(res.body)))[1]) != "ERROR"
+        body = parse_xml(String(res.body))
+        @test isa(body, XMLDict.XMLDictElement)
+        @test first(body)[1] != "ERROR"
 
         res = esummary(db="protein", id=["15718680", "157427902", "119703751"])
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
-        @test isa(parsexml(res.body), EzXML.Document)
-        @test nodename(elements(root(parsexml(res.body)))[1]) != "ERROR"
+        body = parse_xml(String(res.body))
+        @test isa(body, XMLDict.XMLDictElement)
+        @test first(body)[1] != "ERROR"
 
         # esearch then esummary
         query = "asthma[mesh] AND leukotrienes[mesh] AND 2009[pdat]"
@@ -61,7 +66,7 @@
         res = efetch(db="nuccore", id="NM_001178.5", retmode="xml", idtype="acc")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
-        @test isa(parsexml(res.body), EzXML.Document)
+        @test isa(parse_xml(String(res.body)), XMLDict.XMLDictElement)
 
         # epost then efetch
         ctx = Dict()
@@ -75,7 +80,7 @@
         res = elink(dbfrom="protein", db="gene", id="NM_001178.5")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
-        @test isa(parsexml(res.body), EzXML.Document)
+        @test isa(parse_xml(String(res.body)), XMLDict.XMLDictElement)
     end
 
     @testset "egquery" begin
@@ -84,17 +89,16 @@
                               "3000"[Date - Publication])""")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
-        @test isa(parsexml(res.body), EzXML.Document)
+        @test isa(parse_xml(String(res.body)), XMLDict.XMLDictElement)
     end
 
     @testset "espell" begin
         res = espell(db="pmc", term="fiberblast cell grwth")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
-        @test isa(parsexml(res.body), EzXML.Document)
-        doc = parsexml(res.body)
-        spelled_query = elements(root(doc))[4]
-        replaced_spell = nodecontent(elements(spelled_query)[4])
+        @test isa(parse_xml(String(res.body)), XMLDict.XMLDictElement)
+        doc = parse_xml(String(res.body))
+        replaced_spell = doc["SpelledQuery"]["Replaced"][2]
         @test replaced_spell == "growth"
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ module TestBioServices
 
 using BioServices.EUtils
 using BioServices.UMLS
-using EzXML
+using XMLDict
 using Base.Test
 
 all_tests = [


### PR DESCRIPTION
# Change functions to use XMLDict instead of EzXML

## Types of changes

*  :bug: Bug fix (A non-breaking change, which fixes an issue).

## :clipboard: Additional detail
- Functions and tests now use XMLDict to parse xml files.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
