### PR TITLE
Retry responses if we've hit the API limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+### Changes
+- eutils.jl now retries requests that have been rate-limited
+
+
 ## [0.3.2] - 2018-12-13
 ### Changes
 - eutils.jl set `retry_non_idempotent=true` on http requests  
@@ -54,8 +59,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Interfaces to EUtils (Enztrez Utilities) and UMLS (Unified Medical Language System)
   APIs.
 
-
-[Unreleased]: https://github.com/BioJulia/BioServices.jl/compare/v0.2.0...HEAD
+[UNRELEASED]: https://github.com/BioJulia/BioServices.jl/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/BioJulia/BioServices.jl/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/BioJulia/BioServices.jl/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/BioJulia/BioServices.jl/tree/v0.3.0
 [0.2.0]: https://github.com/BioJulia/BioServices.jl/tree/v0.2.0
 [0.1.3]: https://github.com/BioJulia/BioServices.jl/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/BioJulia/BioServices.jl/compare/v0.1.1...v0.1.2

--- a/test/eutils.jl
+++ b/test/eutils.jl
@@ -2,7 +2,6 @@
 @testset "EUtils" begin
 
     @testset "einfo" begin
-        sleep(0.3)
         res = einfo(db="pubmed")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
@@ -12,7 +11,6 @@
     end
 
     @testset "esearch" begin
-        sleep(0.3)
         res = esearch(db="pubmed", term="""(Asthma[MeSH Major Topic]) AND
                                         ("1/1/2018"[Date - Publication] :
                                         "3000"[Date - Publication])""")
@@ -24,7 +22,6 @@
     end
 
     @testset "epost" begin
-        sleep(0.3)
         ctx = Dict()
         res = epost(ctx, db="protein", id="NP_005537")
         @test res.status == 200
@@ -37,7 +34,6 @@
 
     @testset "esummary" begin
         # esummary doesn't seem to support accession numbers
-        sleep(0.3)
         res = esummary(db="protein", id="15718680,157427902,119703751")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
@@ -45,7 +41,6 @@
         @test isa(body, XMLDict.XMLDictElement)
         @test first(body)[1] != "ERROR"
 
-        sleep(0.3)
         res = esummary(db="protein", id=["15718680", "157427902", "119703751"])
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
@@ -54,38 +49,31 @@
         @test first(body)[1] != "ERROR"
 
         # esearch then esummary
-        sleep(0.3)
         query = "asthma[mesh] AND leukotrienes[mesh] AND 2009[pdat]"
         ctx = Dict()
         res = esearch(ctx, db="pubmed", term=query, usehistory=true, retmode="xml")
         @test res.status == 200
-        sleep(0.3)
         res = esummary(ctx, db="pubmed")
         @test res.status == 200
 
-        sleep(0.3)
         ctx = Dict()
         res = esearch(ctx, db="pubmed", term=query, usehistory=true, retmode="json")
         @test res.status == 200
-        sleep(0.3)
         res = esummary(ctx, db="pubmed")
         @test res.status == 200
     end
 
 
     @testset "efetch" begin
-        sleep(0.3)
         res = efetch(db="nuccore", id="NM_001178.5", retmode="xml", idtype="acc")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
         @test isa(parse_xml(String(res.body)), XMLDict.XMLDictElement)
 
         # epost then efetch
-        sleep(0.3)
         ctx = Dict()
         res = epost(ctx, db="protein", id="NP_005537")
         @test res.status == 200
-        sleep(0.3)
         res = efetch(ctx, db="protein", retmode="xml")
         @test res.status == 200
 
@@ -94,7 +82,6 @@
         search_term = """(Asthma[MeSH Major Topic])
                         AND ("1/1/2018"[Date - Publication] :
                         "3000"[Date - Publication])"""
-        sleep(0.3)
         res = esearch(db = "pubmed", term = search_term,
         retstart = 0, retmax = retmax, tool = "BioJulia")
 
@@ -104,7 +91,6 @@
         #get the list of ids and perfom a fetch
         ids = [parse(Int64, id_node) for id_node in esearch_dict["IdList"]["Id"]]
 
-        sleep(0.3)
         res = efetch(db = "pubmed", tool = "BioJulia", retmode = "xml", rettype = "null", id = ids)
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
@@ -117,7 +103,6 @@
     end
 
     @testset "elink" begin
-        sleep(0.3)
         res = elink(dbfrom="protein", db="gene", id="NM_001178.5")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
@@ -125,7 +110,6 @@
     end
 
     @testset "egquery" begin
-        sleep(0.3)
         res = egquery(term="""(Asthma[MeSH Major Topic]) AND
                               ("1/1/2018"[Date - Publication] :
                               "3000"[Date - Publication])""")
@@ -135,7 +119,6 @@
     end
 
     @testset "espell" begin
-        sleep(0.3)
         res = espell(db="pmc", term="fiberblast cell grwth")
         @test res.status == 200
         @test startswith(Dict(res.headers)["Content-Type"], "text/xml")
@@ -146,7 +129,6 @@
     end
 
     @testset "ecitmatch" begin
-        sleep(0.3)
         res = ecitmatch(
             db="pubmed",
             retmode="xml",


### PR DESCRIPTION
This PR changes behaviour so that when a request hits the API limit it is automatically resubmitted after an appropriate delay.

## Types of changes

This PR implements the following changes:

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

When we hit the API limits of EUtils, it responds with an [HTTP 429](https://httpstatuses.com/429) error as well as a[ "Retry-After"](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header indicating the number of seconds to wait before retrying the request.

This PR simply makes our EUtils functions aware of this information, so that requests that are rate-limited will be retried after a given delay. Note that it will retry up to four times before bailing.

A side-effect of this is that an exception is thrown for HTTP responses indicating errors, which may make future errors easier to trouble-shoot, though no additional handling is provided in this PR.

Future work could take advantage of the X-RateLimit-Remaining and X-RateLimit-Limit headers to not bombard the Entrez servers will requests.

This is at least a first step to addressing #14. At the very least, it does make the sleep delays in the tests unnecessary and these have been removed.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [ ] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
