### PR TITLE
Updates to :crossed_fingers: fix the documentation build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ julia:
 matrix:
   allow_failures:
     - julia: nightly
+  include:
+    - stage: deploy docs
+      os: linux
+      julia: 1.2
+      script:
+        - julia --project -e 'import Pkg; Pkg.add("Documenter"); Pkg.add("DocumenterMarkdown")'
+        - julia --project --color=yes docs/make.jl
+      after_success: skip
+        
 notifications:
   email: false
 before_script:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,13 @@
-using Documenter, BioServices
+using Documenter, DocumenterMarkdown, BioServices
 
-makedocs()
+makedocs(
+	format	= Markdown(),
+	sitename= "BioServices.jl"
+)
+
 deploydocs(
-    deps = Deps.pip("mkdocs", "pygments", "mkdocs-material"),
-    repo = "github.com/BioJulia/BioServices.jl.git",
-    julia = "0.6",
-    osname = "linux",
+    deps 	= Deps.pip("mkdocs", "mkdocs-material", "pygments", "python-markdown-math"),
+    repo 	= "github.com/BioJulia/BioServices.jl.git",
+    make 	= () -> run(`mkdocs build`),
+    target 	= "site"
 )

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -34,6 +34,7 @@ markdown_extensions:
   - fenced_code
   - codehilite
   - def_list
+  - mdx_math
 
 # Page tree
 pages:

--- a/docs/src/man/eutils.md
+++ b/docs/src/man/eutils.md
@@ -2,11 +2,9 @@
 CurrentModule = BioServices
 ```
 
-# E-Utilities
+# EUtils
 
-E-Utilities provide a interface to Entrez databases at
-[NCBI](https://www.ncbi.nlm.nih.gov/).  The APIs are defined in the
-`BioServices.EUtils` module, which exports nine functions to access its databases:
+EUtils provide a interface to Entrez databases at [NCBI](https://www.ncbi.nlm.nih.gov/).  The APIs are defined in the `BioServices.EUtils` module, which exports nine functions to access its databases:
 
 | Function    | Description                                                                |
 | :-------    | :----------                                                                |
@@ -20,7 +18,7 @@ E-Utilities provide a interface to Entrez databases at
 | `espell`    | Retrieve spelling suggestions.                                             |
 | `ecitmatch` | Retrieve PubMed IDs that correspond to a set of input citation strings.    |
 
-["The Nine E-utilities in
+["The Nine E-Utilities in
 Brief"](https://www.ncbi.nlm.nih.gov/books/NBK25497/#_chapter2_The_Nine_Eutilities_in_Brief_)
 summarizes all of the server-side programs corresponding to each function.
 
@@ -29,7 +27,7 @@ example, some functions take `db` parameter to specify the target database.
 Functions listed above take these parameters as keyword arguments and return
 a `Response` object as follows:
 ```jlcon
-julia> using BioServices.EUtils      # import the nine functions above
+julia> using BioServices.EUtils       # import the nine functions above
 
 julia> res = einfo(db="pubmed")       # retrieve statistics of the PubMed database
 Response(200 OK, 18 headers, 27360 bytes in body)
@@ -100,12 +98,12 @@ ACGGGAGTGGCGCGCCAGGCCGCGGAAGGGGCGTGGCCT…TGATTAAAAGAACCAAATATTTCTAGTATGAAAAAAAA
 ```
 
 Every function can take a context dictionary as its first argument to set
-parameters into a query. Key-value pairs in a context are appended to a query in
+parameters for a query. Key-value pairs in a context are appended to the query in
 addition to other parameters passed by keyword arguments. The default context
 is an empty dictionary that sets no parameters. This context dictionary is
 especially useful when temporarily caching query UIDs into the Entrez History
 server. A request to the Entrez system can be associated with cached data using
-"WebEnv" and "query_key" parameters. In the following example, the search
+`WebEnv` and `query_key` parameters. In the following example, the search
 results of `esearch` is saved in the Entrez History server (note
 `usehistory=true`, which makes the server cache its search results) and then
 their summaries are retrieved in the next call of `esummary`:

--- a/docs/src/man/gggenome.md
+++ b/docs/src/man/gggenome.md
@@ -4,59 +4,23 @@ CurrentModule=BioServices.GGGenome
 
 # GGGenome
 
-GGGenome is a ultrafast DNA sequence search service hosted by Database Center for Life Science (DBCLS). See "GGGenome Help" (https://gggenome.dbcls.jp/en/help.html) for more details.
+GGGenome is a ultrafast DNA sequence search service hosted by Database Center for Life Science (DBCLS). See [GGGenome Help](https://gggenome.dbcls.jp/en/help.html) for more details.
 
-BioServices.GGGenome is a Julia module interfaces with the [GGGenome REST API](https://gggenome.dbcls.jp) to query a DNA sequence to various databases programmatically.
+`BioServices.GGGenome` is a Julia module interfaces with the [GGGenome REST API](https://gggenome.dbcls.jp) to query a DNA sequence to various databases programmatically.
 
 ## Getting Started
 
 Import module:
 
-```
+```julia
 using BioServices.GGGenome
 ```
-
---------------------------------------------------
-## Method's documentation
---------------------------------------------------
-
-### Retrieve results of gggenome search of a query sequence.
-```@docs
-    gggsearch(query::AbstractString; 
-        db="hg19", k=0, strand=nothing,
-        format="html", timeout=5,
-        output=nothing, show_url=false)
-Retrieve results of gggenome search of a query sequence.
-
-# Arguments
-## Required
-- `query::String`: Nucleotide sequence, case insensitive.
-
-## Optional
-- `db::String`: Target database name. hg19 if not specified. Full list of databases: https://gggenome.dbcls.jp/en/help.html#db_list
-- `k::Integer`: Maximum number of mismatches/gaps. 0 if not specified.
-- `strand::String`: '+' ('plus') or '-' ('minus') to search specified strand only.
-- `format::String`: [html|txt|csv|bed|gff|json]. html if not specified.
-- `timeout::Integer`
-- `output::String`: If "toString", a String object is returned. If "extractTopHit", a String object containing only top hit is returned (Currently, only works with format="txt"). Otherwise, A HTTP.Messages.Response object is returned.
-- `show_url::Bool`: If true, print URL of REST API.
-```
---------------------------------------------------
-
-### Retrieve full list of available databases
-```@docs
-    gggdbs()
-Retrieve full list of available databases.
-Full list of databases: https://gggenome.dbcls.jp/en/help.html#db_list..
-```
---------------------------------------------------
-
 
 ## Available Databases
 
 Genome sequences (`hg19`, `mm10`, `dm3`, `ce10`, `TAIR10`, `pombe`, etc.) and other sequence databases (e.g., `refseq`) are available.
 
-Full list of available databases is https://gggenome.dbcls.jp/en/mm10/help.html#db_list.
+Full list of available databases can be found at [https://gggenome.dbcls.jp/en/mm10/help.html#db_list].
 
 ## Examples
 ### Example 1
@@ -101,10 +65,9 @@ chr1    +       98281503        98281520        TCTAGTGAGGAGAAATGTAAGCTAACGTGATA
 ...
 ```
 
+## Understanding `output` parameters
 
-### Understanding `output` parameters
-
-By default, `gggsearch()` returns a HTTP.Messages.Response object.
+By default, `gggsearch()` returns a `HTTP.Messages.Response` object.
 
 ```
 julia> query = "GTGCGGTAACGCGACCGATCCCGGAGAAGCCGGCGGGA";
@@ -115,8 +78,7 @@ julia> typeof(res)
 HTTP.Messages.Response
 ```
 
-By setting `output="toString"`, `gggsearch()` returns a String object.
-
+By setting `output="toString"`, `gggsearch()` returns a `String` object.
 
 ```
 julia> query = "GTGCGGTAACGCGACCGATCCCGGAGAAGCCGGCGGGA";
@@ -139,7 +101,7 @@ NR_003287.4 Homo sapiens RNA, 28S ribosomal N5 (RNA28SN5), ribosomal RNA        
 ...
 ```
 
-By setting `output="extractTopHit"`, `gggsearch()` returns a String object containing the top hit (Currently, only works with `format="txt"`).
+By setting `output="extractTopHit"`, `gggsearch()` returns a `String` object containing the top hit. Currently, this only works with `format="txt"`.
 
 ```
 julia> query = "GTGCGGTAACGCGACCGATCCCGGAGAAGCCGGCGGGA";
@@ -152,3 +114,35 @@ String
 julia> println(res)
 NR_003279.1 Mus musculus 28S ribosomal RNA (Rn28s1), ribosomal RNA      +       2326    2363    GAAGGGACGGGCGATGGCCTCCGTTGCCCTCGGCCGATCGAAAGGGAGTCGGGTTCAGATCCCCGAATCCGGAGTGGCGGAGATGGGCGCCGCGAGGCCAGTGCGGTAACGCGACCGATCCCGGAGAAGCCGGCGGGAGGCCTCGGGGAGAGTTCTCTTTTCTTTGTGAAGGGCAGGGCGCCCTGGAATGGGTTCGCCCCGAGAGAGGGGCCCGTGCCTTGGAAAGCGTCGCGGTTCC      2226    2463
 ```
+
+## Methods
+
+```@docs
+    gggsearch(query::AbstractString; 
+        db="hg19", k=0, strand=nothing,
+        format="html", timeout=5,
+        output=nothing, show_url=false)
+Retrieve results of gggenome search for a nucleotide sequence.
+
+# Arguments
+## Required
+- `query::String`: Nucleotide sequence, case insensitive.
+
+## Optional
+- `db::String`: Target database name. hg19 if not specified. Full list of databases: https://gggenome.dbcls.jp/en/help.html#db_list
+- `k::Integer`: Maximum number of mismatches/gaps. 0 if not specified.
+- `strand::String`: '+' ('plus') or '-' ('minus') to search specified strand only.
+- `format::String`: [html|txt|csv|bed|gff|json]. html if not specified.
+- `timeout::Integer`
+- `output::String`: If "toString", a String object is returned. If "extractTopHit", a String object containing only top hit is returned (Currently, only works with format="txt"). Otherwise, A HTTP.Messages.Response object is returned.
+- `show_url::Bool`: If true, print URL of REST API.
+```
+--------------------------------------------------
+
+```@docs
+    gggdbs()
+Retrieve full list of available databases.
+
+Full list of databases: [https://gggenome.dbcls.jp/en/help.html#db_list].
+```
+--------------------------------------------------

--- a/docs/src/man/umls.md
+++ b/docs/src/man/umls.md
@@ -4,88 +4,79 @@ CurrentModule = BioServices.UMLS
 
 # UMLS
 
-The Unified Medical Language System (UMLS) brings together many health and biomedical vocabularies and standards to enable interoperability between systems. [UMLS Quick Start Guide](https://www.nlm.nih.gov/research/umls/quickstart.html) provides an overview of the software, tools and services associated with the UMLS.
+The Unified Medical Language System (UMLS) brings together many health and biomedical vocabularies and standards to enable interoperability between biomedical information systems and services. The [UMLS Quick Start Guide](https://www.nlm.nih.gov/research/umls/quickstart.html) provides an overview of the software, tools and services associated with the UMLS.
 
-BioServices.UMLS is a Julia module that interfaces with the [UMLS REST API](https://documentation.uts.nlm.nih.gov/rest/home.html) to query the UMLS data programmatically.
+`BioServices.UMLS` is a Julia module that interfaces with the [UMLS REST API](https://documentation.uts.nlm.nih.gov/rest/home.html) to query the UMLS data programmatically.
 
 
 ## Getting Started
 
-1. [Sing up]((https://uts.nlm.nih.gov/license.html)) for a UMLS Terminology Services (UTS) account, where you agree to their terms of use.
+1. [Sign up](https://uts.nlm.nih.gov/license.html) for a UMLS Terminology Services (UTS) account, where you agree to their terms of use.
 
-2. Import module:
+2. Import the module:
 
-    ```
+    ```julia
     using BioServices.UMLS
     ```
 
 ## Available Endpoints
 
-For a  complete list of the enpoints made available in the REST API visit the [REST API Documentation](https://documentation.uts.nlm.nih.gov/rest/home.html)
+For a  complete list of the endpoints available through the UMLS REST API visit the [UMLS REST API Documentation](https://documentation.uts.nlm.nih.gov/rest/home.html).
 
-This module focuses in the following three enpoints. (Request to expand API is encouraged trhough pull requests or issues in out GitHub repository.)
+This module focuses on the following three endpoints. (Requests to expand API are encouraged through pull requests or issues in out GitHub repository.)
 
 | EndPoint                                  | Description                   | 
 | :-------                                  | :----------                   |
 | /cas/v1/tickets                           | Authentication                |
-| /search/version                           | Retrieves CUI when searching by term or code|
-| /content/version/CUI                      | Retrieves information about a known CUI|
+| /search/version                           | Retrieves <abbr title="Concept Unique Identifier">CUI</abbr> when searching by term or code|
+| /content/version/CUI                      | Retrieves information about a known <abbr title="Concept Unique Identifier">CUI</abbr>|
 
-* CUI refers to Concept Unique Identifier 
-
--------------------
 ## Exported Functions
 
-The following functions access the mentioned enpoints. See the [method's documentation](#methods-documentation) for specific usage
+The following functions access the above enpoints. See the [method documentation](#Methods-1) for specific usage.
 
 | Function                                | Description                   | 
 | :-------                                | :----------                   |
 | [`get_tgt`](#get-ticket-granting-ticket)| Get a ticket-granting ticket  |
 | [`search_umls`](#search-umls)           | Search UMLS Rest API          |
 | [`best_match_cui`](#best-cui)           | Return concept ID of best match for a serach|
-| [`get-cui`](#search-based-on-cui)       | Get information associated with a Concept ID(CUI)|
-| [`get_semantic_types`](#semantic-types) | Retrieve smenatic types associated with a CUI|
-
--------------------
+| [`get-cui`](#search-based-on-cui)       | Get information associated with a Concept ID (<abbr title="Concept Unique Identifier">CUI</abbr>)|
+| [`get_semantic_types`](#semantic-types) | Retrieve smenatic types associated with a <abbr title="Concept Unique Identifier">CUI</abbr>|
 
 ## Sample workflow
 
-Service tickets are needed each time you search or retrieve content from the UMLS REST API. 
-A service ticket is retrieved automatically by this software from a **ticket granting ticket**.
+Service tickets are needed each time you search or retrieve content from the UMLS REST API. A service ticket is retrieved automatically by this software from a **ticket granting ticket**. Thus, the first step of your workflow must start by requesting a **ticket granting ticket** using your credentials. There are two ways you can do this:
 
-Therefore, the first step of your workflow must start by requesting a **ticket granting ticket**
-from your credentials. Two methods are available
-
-**Use username and password**
+**1. Use username and password**
 ```julia
     user = "myuser"
     psswd = "mypsswd"
     tgt = get_tgt(username=user, password=psswd)
 ```
-**Use API KEY**
+
+**2. Use API KEY**
 ```julia
     apikey = "myapikey"
     tgt = get_tgt(apikey=apikey)
 ```
 
-According to the UMLS documentation. **Ticket granting tickets** are valid for 8 hours, therefore we locally store the ticket in a file and 
-reuse it if it has not expired. If you get errors, you can force getting a new ticket. For instance
+According to the UMLS documentation, **ticket granting tickets** are valid for 8 hours, therefore we locally store the ticket in a file and reuse it as long as it has not expired. If you get errors, you can force the `get_tgt` function to get a new ticket. For instance:
 
 ```julia
    tgt = get_tgt(force_new=true, apikey=apikey)
 ```
 
-After authentication, you can query the CUI associated with a term (e.g obesity) and the semantic types associated with that term (e.g obesity is a Disease or Syndrome)
+After authentication, you can query the <abbr title="Concept Unique Identifier">CUI</abbr> associated with a term (e.g obesity) to get the semantic type(s) associated with that term (e.g obesity is a Disease or Syndrome)
 
 ```julia
     term = "obesity"
     query = Dict("string"=>term, "searchType"=>"exact" )
     all_results= search_umls(tgt, query)
-    cui = best_match_cui(all_results)   #cui="C0028754"
-    sm = get_semantic_types(tgt, cui)   #sm[1] == "Disease or Syndrome"
+    cui = best_match_cui(all_results)   # cui="C0028754"
+    sm = get_semantic_types(tgt, cui)   # sm[1] == "Disease or Syndrome"
 ```
 
-__Options for searchType__
+**Options for searchType**
 
 * Word: breaks a search term into its component parts, or words, and retrieves all concepts containing any of those words. For example: If you enter "Heart Disease, Acute" a Word search will retrieve all concepts containing any of the three words (heart, or disease, or acute). Word is the default Search Type selection and is appropriate for both English and non-English search terms.
 * Approximate Match: applies lexical variant generation (LVG) rules to the search term and generally results in expanded retrieval of concepts. For example, a search for the term "cold" retrieves all concepts that contain any of the following words: COLDs, chronic obstructive lung disease, chronic obstructive lung diseases, cold, colder, coldest.
@@ -95,37 +86,27 @@ __Options for searchType__
 * Right Truncation: retrieves concepts with synonyms that begin with the letters of the search term. For example, a right truncation search for "bronch" retrieves concepts that contain synonyms such as bronchitis, bronchiole, bronchial artery.
 * Left Truncation: retrieves concepts with synonyms that end with the letters of the search term. For example, a left truncation search for "itis" retrieves concepts that contain synonyms such as colitis, bronchitis, pancreatitis.
 
---------------------------------------------------
-## Method's documentation
---------------------------------------------------
+## Methods
 
-### Get ticket-granting ticket 
 ```@docs
  get_tgt(; force_new::Bool = false, kwargs...)
 ```
 --------------------------------------------------
-
-### Search UMLS
 
 ```@docs
 search_umls(tgt, query; version::String="current", timeout=1)
 ```
 --------------------------------------------------
 
-### Best CUI
-
 ```@docs
  best_match_cui(result_pages)
 ```
 --------------------------------------------------
 
-### Search based on CUI
 ```@docs
  get_cui(tgt,cui)
 ```
 --------------------------------------------------
-
-### Semantic types
 
 ```@docs
 get_semantic_types(tgt, cui; version="current")


### PR DESCRIPTION
Somewhere along the line of Julia updates, the docs build seem to broke. See [e.g., this Travis failed build](https://travis-ci.org/BioJulia/BioServices.jl/jobs/592564365#L290). This PR fixes the issue (🤞).

## Types of changes

This PR implements the following changes:

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented are consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [ ] :ok: There are unit tests that cover the code changes I have made.
- [ ] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
